### PR TITLE
Add privacy policy and contact email to settings

### DIFF
--- a/TinyMoonApp/Views/SettingsView.swift
+++ b/TinyMoonApp/Views/SettingsView.swift
@@ -53,9 +53,15 @@ struct SettingsView: View {
     Text(MoonViewModel.appVersion)
   }
 
+  @ViewBuilder
   private var about: some View {
-    Text("Info")
-      .foregroundStyle(.blue)
+    Link("Contact", destination: URL(string: "https://github.com/mannylopez/TinyMoonApp/issues/21") ?? URL(string: "mailto:TinyMoonApp@gmail.com")!)
+      .onAppear {
+        // Set focus to nil to remove focus from the settings button
+        DispatchQueue.main.async {
+          NSApplication.shared.keyWindow?.makeFirstResponder(nil)
+        }
+      }
   }
 
   private var launchAtLoginToggleButton: some View {


### PR DESCRIPTION
Closes #3. 

![image](https://github.com/mannylopez/TinyMoonApp/assets/3945073/6547d9f0-9d30-41be-8d42-f74961bad997)


Tapping on "Contact" will either open the privacy policy (https://github.com/mannylopez/TinyMoonApp/issues/21) or open sendTo email